### PR TITLE
extend fill-table to support mapping files

### DIFF
--- a/tests/test_fill_table.py
+++ b/tests/test_fill_table.py
@@ -33,3 +33,10 @@ class TestDataFaker(TestCase):
     def test_timestamp_type_default(self):
         provider = self.f.provider_for_column('some_ts_column', 'timestamp')
         self.assertEqual(provider(), 1373158606000)
+
+    def test_provider_from_mapping(self):
+        mapping = {'x': ['random_int', [10, 20]]}
+        provider = self.f.provider_from_mapping('x', mapping)
+        self.assertEqual(provider(), 20)
+
+


### PR DESCRIPTION
Previously it was required for the column names to map to a fake
provider.

Now this requirement is gone as an additional mapping file (in JSON
format) can be supplied which can be used to declare column-name to
provider-name mappings.